### PR TITLE
feat(checking): Added maybe vegan status

### DIFF
--- a/src/app/models/checking.py
+++ b/src/app/models/checking.py
@@ -9,6 +9,7 @@ class CheckingStatus(str, enum.Enum):
     PENDING = "PENDING"
     VEGAN = "VEGAN"
     NON_VEGAN = "NON_VEGAN"
+    MAYBE_VEGAN = "MAYBE_VEGAN"
 
 class Checking(Base):
     __tablename__ = "checkings"


### PR DESCRIPTION
Hi @llambrecht!

I've added the status maybe vegan to the CheckingStatus enum to make it work to publish a product for which we don't have an answer from the manufacturers. 

If this suits you, the value should be added to the db during the update: 
```sh
ALTER TYPE checkingstatus ADD VALUE 'MAYBE_VEGAN';
```
A beautiful day to you!